### PR TITLE
Making EAMP fields mandatory

### DIFF
--- a/src/main/plugin/iso19139.eamp/schema/extensions/eamp4.xsd
+++ b/src/main/plugin/iso19139.eamp/schema/extensions/eamp4.xsd
@@ -43,7 +43,7 @@
 		<xs:complexContent>
 			<xs:extension base="gmd:MD_Constraints_Type">
 				<xs:sequence>
-					<xs:element name="afa" type="eamp:EA_Afa_PropertyType" minOccurs="0" maxOccurs="1"/>
+					<xs:element name="afa" type="eamp:EA_Afa_PropertyType" minOccurs="1" maxOccurs="1"/>
 				</xs:sequence>
 				<xs:attribute ref="gco:isoType" use="required" fixed="gmd:MD_Constraints"/>
 			</xs:extension>
@@ -69,9 +69,9 @@
 			<xs:extension base="gco:AbstractObject_Type">
 				<xs:sequence>
 					<!-- For the AfA status - restricted list, see below - implement as codelist (needs to be done). -->
-					<xs:element name="afaNumber" type="gco:Integer_PropertyType" minOccurs="0" maxOccurs="1"/>
+					<xs:element name="afaNumber" type="gco:Integer_PropertyType" minOccurs="1" maxOccurs="1"/>
 					<!-- For the AfA status - restricted list, see below - implement as codelist (needs to be done). -->
-					<xs:element name="afaStatus" type="eamp:EA_AfaStatus_PropertyType" minOccurs="0" maxOccurs="1"/>
+					<xs:element name="afaStatus" type="eamp:EA_AfaStatus_PropertyType" minOccurs="1" maxOccurs="1"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
@@ -80,7 +80,7 @@
 	<xs:element name="EA_Afa" type="eamp:EA_Afa_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="EA_Afa_PropertyType">
-		<xs:sequence minOccurs="0">
+		<xs:sequence minOccurs="1">
 			<xs:element ref="eamp:EA_Afa"/>
 		</xs:sequence>
 		<xs:attribute ref="gco:nilReason"/>
@@ -104,7 +104,7 @@
 	<xs:element name="EA_AfaStatus" type="eamp:EA_AfaStatus_Type" substitutionGroup="gco:CharacterString"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="EA_AfaStatus_PropertyType">
-		<xs:sequence minOccurs="0">
+		<xs:sequence minOccurs="1">
 			<xs:element ref="eamp:EA_AfaStatus"/>
 		</xs:sequence>
 		<xs:attribute ref="gco:nilReason"/>

--- a/src/main/plugin/iso19139.eamp/schema/extensions/eamp5.xsd
+++ b/src/main/plugin/iso19139.eamp/schema/extensions/eamp5.xsd
@@ -45,7 +45,7 @@
 		<xs:complexContent>
 			<xs:extension base="gmd:MD_Constraints_Type">
 				<xs:sequence>
-					<xs:element name="afa" type="eamp:EA_Afa_PropertyType" minOccurs="0"/>
+					<xs:element name="afa" type="eamp:EA_Afa_PropertyType" minOccurs="1"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
@@ -69,9 +69,9 @@
 			<xs:extension base="gco:AbstractObject_Type">
 				<xs:sequence>
 					<!-- For the AfA status - restricted list, see below - implement ass codelist (needs to be done). -->
-					<xs:element name="afaNumber" type="gco:Decimal_PropertyType" minOccurs="0"/>
+					<xs:element name="afaNumber" type="gco:Decimal_PropertyType" minOccurs="1"/>
 					<!-- For the AfA status - restricted list, see below - implement ass codelist (needs to be done). -->
-					<xs:element name="afaStatus" type="eamp:EA_AfaStatus_PropertyType" minOccurs="0"/>
+					<xs:element name="afaStatus" type="eamp:EA_AfaStatus_PropertyType" minOccurs="1"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
@@ -80,7 +80,7 @@
 	<xs:element name="EA_Afa" type="eamp:EA_Afa_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="EA_Afa_PropertyType">
-		<xs:sequence minOccurs="0">
+		<xs:sequence minOccurs="1">
 			<xs:element ref="eamp:EA_Afa"/>
 		</xs:sequence>
 		<xs:attribute ref="gco:nilReason"/>
@@ -105,7 +105,7 @@
 	<xs:element name="EA_AfaStatus" type="eamp:EA_AfaStatus_Type" substitutionGroup="gco:CharacterString"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="EA_AfaStatus_PropertyType">
-		<xs:sequence minOccurs="0">
+		<xs:sequence minOccurs="1">
 			<xs:element ref="eamp:EA_AfaStatus"/>
 		</xs:sequence>
 		<xs:attribute ref="gco:nilReason"/>


### PR DESCRIPTION
If the EA Afa elements are mandatory, why are they defined as optional in the XSD? If we change all the minOccurs from 0 to 1 related to this elements (in eamp4.xsd and eamp5.xsd), the EA Afa elements are added by default properly on all the EA_Constraints. So no need to add them on the dropdown list of the useLimitation. Is this what you want? That EA Afa elements are mandatory on all the EA Constraints?

Regarding the options, if we limit the options of the useLimitation to the three options we want (gco:CharacterString, gmx:Anchor and eamp:AF_Element) the problem is that the eamp is not correctly understood and only the first two options appear. I don't know if @josegar74  knows a clean workaround for this...